### PR TITLE
versions.tf: terraform and hcloud_provider

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -6,7 +6,7 @@ locals {
 }
 
 module "controller-init" {
-  source = "git::https://github.com/squat/hetzner-cloud-flatcar-linux.git?ref=985afb1c7bb4a0159ae77acf6a6be6011bf859ed"
+  source = "git::https://github.com/squat/hetzner-cloud-flatcar-linux.git?ref=285559d091fd651ba41fdb7c5af9b75c787feb5c"
   count  = local.count_init
 
   name = "${var.cluster_name}-controller-${count.index}"
@@ -25,7 +25,7 @@ module "controller-init" {
 }
 
 module "controllers-join" {
-  source = "git::https://github.com/squat/hetzner-cloud-flatcar-linux.git?ref=985afb1c7bb4a0159ae77acf6a6be6011bf859ed"
+  source = "git::https://github.com/squat/hetzner-cloud-flatcar-linux.git?ref=285559d091fd651ba41fdb7c5af9b75c787feb5c"
   count  = local.count_join
 
   name = "${var.cluster_name}-controller-${count.index + 1}"
@@ -84,7 +84,7 @@ data "template_file" "kubeadm-config-join" {
 
 resource "random_password" "certificate_key" {
   length           = 64
-  number           = false
+  numeric          = false
   lower            = false
   upper            = false
   special          = true
@@ -93,7 +93,7 @@ resource "random_password" "certificate_key" {
 
 resource "random_password" "token-1" {
   length  = 6
-  number  = true
+  numeric = true
   lower   = true
   special = false
   upper   = false
@@ -101,7 +101,7 @@ resource "random_password" "token-1" {
 
 resource "random_password" "token-2" {
   length  = 16
-  number  = true
+  numeric = true
   lower   = true
   special = false
   upper   = false

--- a/versions.tf
+++ b/versions.tf
@@ -1,9 +1,9 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.14"
   required_providers {
     hcloud = {
       source  = "hetznercloud/hcloud"
-      version = "1.23.0"
+      version = ">= 1.23, < 2"
     }
     template = {
       source  = "hashicorp/template"

--- a/workers.tf
+++ b/workers.tf
@@ -1,5 +1,5 @@
 module "workers" {
-  source = "git::https://github.com/squat/hetzner-cloud-kubeadm-workers.git?ref=458417dc1229914b97fa5393176acf69fe3c6e26"
+  source = "git::https://github.com/squat/hetzner-cloud-kubeadm-workers.git?ref=b0626e23210b6a731694aabafbd38c255c774cf2"
 
   api                = "${hcloud_load_balancer.lb.ipv4}:6443"
   token              = local.token


### PR DESCRIPTION
 - update terraform and replace deprecated fields
 - allow modules importing this module to use higher version of hcloud_provider
